### PR TITLE
Restore authenticated MuckRock v1 downloads safely

### DIFF
--- a/.github/workflows/etl.yaml
+++ b/.github/workflows/etl.yaml
@@ -2,13 +2,23 @@ name: "Extract, transform and alert"
 
 on:
   workflow_dispatch:
+    inputs:
+      baseline:
+        description: "Save all public requests without posting; acknowledges anonymous-feed exclusions may differ"
+        type: boolean
+        default: false
   schedule:
     - cron: "30 * * * *"
+
+concurrency:
+  group: muckrockbot-etl
+  cancel-in-progress: false
 
 jobs:
   run:
     name: Run
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: write
     steps:
@@ -24,13 +34,25 @@ jobs:
       - name: Install dependencies
         run: uv sync --locked
 
+      - id: check
+        name: Check authenticated access without saving or posting
+        if: vars.MUCKROCK_PUBLIC_FEED_APPROVED != 'true' && !inputs.baseline
+        run: uv run python -m muckrockbot.download --check
+        env:
+          MUCKROCK_API_TOKEN: ${{ secrets.MUCKROCK_API_TOKEN }}
+
       - id: download
         name: Download
+        if: vars.MUCKROCK_PUBLIC_FEED_APPROVED == 'true' || inputs.baseline
         run: make download
         shell: bash
+        env:
+          MUCKROCK_API_TOKEN: ${{ secrets.MUCKROCK_API_TOKEN }}
+          MUCKROCK_PUBLIC_FEED_APPROVED: "true"
 
       - id: transform
         name: Identify new requests
+        if: vars.MUCKROCK_PUBLIC_FEED_APPROVED == 'true' && !inputs.baseline
         run: make transform
         shell: bash
 
@@ -46,6 +68,7 @@ jobs:
 
       - id: toot
         name: Send toots
+        if: vars.MUCKROCK_PUBLIC_FEED_APPROVED == 'true' && !inputs.baseline
         run: make toot
         shell: bash
         env:
@@ -55,12 +78,13 @@ jobs:
 
       - id: commit
         name: Commit
+        if: vars.MUCKROCK_PUBLIC_FEED_APPROVED == 'true' || inputs.baseline
         run: |
           git config --global user.name "GitHub Actions"
           git config --global user.email "actions@github.com"
           git config pull.rebase false
-          git pull --rebase origin "$GITHUB_REF_NAME"
-          git add ./
+          git add data/submitted data/completed
           git diff --cached --quiet || git commit -m "Added latest ETL" --author="palewire <palewire@users.noreply.github.com>"
+          git pull --rebase origin "$GITHUB_REF_NAME"
           git push
         shell: bash

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-A Fediverse robot account that posts the latest public records requests filed and completed at muckrock.com at [mastodon.palewi.re/@muckrockbot](https://mastodon.palewi.re/@muckrockbot).
+A Fediverse robot account that posts the latest public records requests filed
+at muckrock.com at [mastodon.palewi.re/@muckrockbot](https://mastodon.palewi.re/@muckrockbot).
+It also saves completed-request snapshots, but does not post them.
 
 ## Development
 
@@ -11,17 +13,74 @@ make check
 make test
 ```
 
-Use `make fix` to apply safe lint and formatting changes. The scheduled
-workflow uses `make download`, `make transform`, and `make toot`.
+Use `make fix` to apply safe lint and formatting changes. Tests use fake API
+responses and temporary data directories. They never call MuckRock or post to
+social accounts.
 
-## MuckRock API migration
+## Restore authenticated downloads
 
-The current download command uses MuckRock's retired v1 client interface. A
-production move to API v2 is intentionally paused: v2 requires a bot account
+API v1 remains available with a legacy API token. The bot intentionally uses
+`python-muckrock==0.1.1` to preserve its request filters, author credits and
+links. Obtain your token from MuckRock through a secure channel and save it
+as the `MUCKROCK_API_TOKEN` GitHub Actions secret. Do not put tokens in files,
+command arguments, logs or commits.
+
+For local use, supply the same environment variable through your secret
+manager. Then check authentication and both response shapes without saving
+anything or posting:
+
+```sh
+uv run python -m muckrockbot.download --check
+```
+
+Downloads request one page of up to 50 public records per feed, ordered newest
+first. Submitted requests must have a submission date. Completed requests must
+have a completion date and status `done`. Both feeds are validated before any
+snapshots are written; invalid credentials, HTTP failures and malformed
+responses fail the command rather than replacing good data with an error.
+This is not a historical download or recovery system: requests outside the
+latest 50 can be missed between runs.
+
+### Public-record approval and restarting posts
+
+Authentication changes which records the API can return. The bot explicitly
+requests and checks `embargo_status=public` and excludes authenticated-only
+account fields from snapshots. However, v1 does not identify public records
+marked `noindex`, which were excluded from the previous anonymous feed.
+Token access alone does **not** resolve that difference.
+
+Until you approve including all records marked public, or MuckRock provides
+a supported way to preserve the old exclusions, leave the repository variable
+`MUCKROCK_PUBLIC_FEED_APPROVED` unset. Scheduled runs will only perform the
+read-only check: no snapshots, commits, transformations or social posts.
+
+If you explicitly approve the broader public feed, restart in this order:
+
+1. Run the **Extract, transform and alert** workflow manually with `baseline`
+   selected. This acknowledges the visibility difference, saves a current
+   snapshot, and never sends posts. It avoids announcing the entire newest
+   page after the bot's downtime. Wait for that run to finish successfully.
+2. Set the GitHub Actions **repository variable** `MUCKROCK_PUBLIC_FEED_APPROVED`
+   to the exact value `true`. Subsequent scheduled runs download, compare,
+   post to Mastodon and commit snapshots. Twitter remains disabled.
+
+Unset that variable to return to read-only checks. If preserving the old
+`noindex` exclusions is required, do not select `baseline` or enable the
+variable; resolve the API limitation with the maintainer first.
+
+Local snapshot writing also requires explicit approval:
+
+```sh
+uv run python -m muckrockbot.download --allow-public-feed --data-dir /tmp/muckrockbot
+```
+
+This saves data but does not post. Use a fresh temporary directory for manual
+experiments rather than changing the checked-in snapshots.
+
+## Later API v2 migration
+
+A production move to API v2 remains separate: v2 requires a bot account
 with JWT authentication and does not provide the public author name or
 `noindex` visibility information that this bot needs to preserve its existing
 posts and public-only feed. Do not update `python-muckrock` beyond `0.1.1` or
 enable v2 downloads until MuckRock provides supported access to those fields.
-
-Tests use fake API responses and temporary data directories. They never call
-MuckRock or post to social accounts.

--- a/muckrockbot/client.py
+++ b/muckrockbot/client.py
@@ -1,0 +1,231 @@
+"""Authenticated, public-only downloads through MuckRock's v1 client."""
+
+from datetime import datetime
+from typing import ClassVar
+from urllib.parse import urlsplit
+
+import requests
+from muckrock import FoiaEndpoint
+
+RequestRecord = dict[str, object]
+
+
+class DownloadError(ValueError):
+    """A download failed without producing a usable snapshot."""
+
+
+class PublicFoiaClient(FoiaEndpoint):
+    """Keep legacy query encoding while validating HTTP responses and records."""
+
+    USER_AGENT = "muckrockbot (https://github.com/palewire/muckrockbot)"
+    SNAPSHOT_FIELDS: ClassVar[tuple[str, ...]] = (
+        "id",
+        "title",
+        "username",
+        "absolute_url",
+        "user",
+        "agency",
+        "slug",
+        "status",
+        "embargo_status",
+        "datetime_submitted",
+        "datetime_done",
+        "datetime_updated",
+        "date_due",
+        "date_embargo",
+        "date_followup",
+        "days_until_due",
+        "disable_autofollowups",
+        "price",
+        "tracking_id",
+        "tags",
+        "communications",
+    )
+
+    def __init__(self, token: str) -> None:
+        """Create a client using a legacy API token.
+
+        Args:
+            token: Token supplied through the MUCKROCK_API_TOKEN environment variable.
+
+        Returns:
+            None.
+
+        Raises:
+            DownloadError: The token is empty or contains invalid header characters.
+
+        Example:
+            ``client = PublicFoiaClient(token_from_environment)``
+        """
+        if not token.strip() or any(character in token for character in "\r\n"):
+            raise DownloadError("Set MUCKROCK_API_TOKEN to a valid legacy API token.")
+        super().__init__(token=token.strip())
+
+    def submitted(self) -> list[RequestRecord]:
+        """Fetch the first page of submitted public requests.
+
+        Args:
+            None.
+
+        Returns:
+            At most 50 JSON-compatible requests, newest first.
+
+        Raises:
+            DownloadError: The download or response validation fails.
+
+        Example:
+            ``submitted = client.submitted()``
+        """
+        return self.filter(ordering="-datetime_submitted", has_datetime_submitted=True)
+
+    def completed(self) -> list[RequestRecord]:
+        """Fetch the first page of successfully completed public requests.
+
+        Args:
+            None.
+
+        Returns:
+            At most 50 JSON-compatible requests with status ``done``, newest first.
+
+        Raises:
+            DownloadError: The download or response validation fails.
+
+        Example:
+            ``completed = client.completed()``
+        """
+        return self.filter(
+            ordering="-datetime_done", has_datetime_done=True, status="done"
+        )
+
+    def _get_request(
+        self,
+        url: str,
+        params: dict[str, str | int] | None = None,
+        headers: dict[str, str] | None = None,
+    ) -> dict[str, list[RequestRecord]]:
+        """Replace the legacy transport's unchecked JSON response.
+
+        Args:
+            url: Legacy endpoint URL supplied by FoiaEndpoint.
+            params: Query parameters already encoded by the legacy client.
+            headers: Additional HTTP headers supplied by the legacy client.
+
+        Returns:
+            A results envelope containing validated snapshot records.
+
+        Raises:
+            DownloadError: Authentication, HTTP, JSON, or record validation fails.
+
+        Example:
+            ``client.submitted()`` calls this transport through ``filter()``.
+        """
+        query = {**(params or {}), "embargo_status": "public", "page_size": 50}
+        request_headers = {
+            **(headers or {}),
+            "Authorization": f"Token {self.token}",
+            "User-Agent": self.USER_AGENT,
+            "Accept": "application/json",
+        }
+        try:
+            response = requests.get(
+                url, params=query, headers=request_headers, timeout=20
+            )
+            response.raise_for_status()
+        except requests.HTTPError as error:
+            status = error.response.status_code if error.response is not None else None
+            if status in (401, 403):
+                raise DownloadError(
+                    "MuckRock rejected access. Check MUCKROCK_API_TOKEN; "
+                    "if it is valid, contact MuckRock about the access restriction."
+                ) from None
+            if status == 429:
+                raise DownloadError(
+                    "MuckRock's rate limit was reached. Wait before trying again."
+                ) from None
+            raise DownloadError(f"MuckRock returned HTTP {status}.") from None
+        except requests.RequestException:
+            raise DownloadError(
+                "Could not reach MuckRock within the request timeout. Try again later."
+            ) from None
+
+        try:
+            payload = response.json()
+        except ValueError:
+            raise DownloadError(
+                "MuckRock returned invalid JSON, not a results page."
+            ) from None
+        if not isinstance(payload, dict) or not isinstance(
+            payload.get("results"), list
+        ):
+            raise DownloadError("MuckRock's response is missing a results list.")
+        if len(payload["results"]) > 50:
+            raise DownloadError("MuckRock returned more than the requested 50 records.")
+
+        date_field = (
+            "datetime_done"
+            if query.get("ordering") == "-datetime_done"
+            else "datetime_submitted"
+        )
+        records = [
+            self._validate_record(item, date_field) for item in payload["results"]
+        ]
+        ids = [record["id"] for record in records]
+        if len(set(ids)) != len(ids):
+            raise DownloadError("MuckRock returned duplicate request IDs.")
+        return {"results": records}
+
+    def _validate_record(self, item: object, date_field: str) -> RequestRecord:
+        """Validate a public request and exclude authenticated-only metadata.
+
+        Args:
+            item: A decoded JSON result.
+            date_field: Timestamp required for the requested feed.
+
+        Returns:
+            The request's existing snapshot fields, without private account metadata.
+
+        Raises:
+            DownloadError: A required field, public status, date, or link is invalid.
+
+        Example:
+            ``client._validate_record(api_row, "datetime_submitted")``
+        """
+        if not isinstance(item, dict):
+            raise DownloadError("MuckRock returned a request that is not an object.")
+        if type(item.get("id")) is not int or item["id"] <= 0:
+            raise DownloadError(
+                "MuckRock returned a request without a valid integer ID."
+            )
+        for field in ("title", "username", "absolute_url", "status", date_field):
+            value = item.get(field)
+            if not isinstance(value, str) or not value.strip():
+                raise DownloadError(
+                    f"MuckRock returned a request without a valid {field}."
+                )
+        if item.get("embargo_status") != "public":
+            raise DownloadError(
+                "MuckRock returned a non-public request. No files were written."
+            )
+        if date_field == "datetime_done" and item["status"] != "done":
+            raise DownloadError(
+                "MuckRock returned a completed request without status done."
+            )
+
+        try:
+            datetime.fromisoformat(item[date_field])
+            link = urlsplit(item["absolute_url"])
+        except ValueError:
+            raise DownloadError(
+                "MuckRock returned an invalid request date or URL."
+            ) from None
+        if (
+            link.scheme != "https"
+            or link.netloc != "www.muckrock.com"
+            or not link.path.startswith("/foi/")
+        ):
+            raise DownloadError(
+                "MuckRock returned a request URL outside its public site."
+            )
+
+        # Staff and owner responses can contain fields that must never reach git.
+        return {field: item[field] for field in self.SNAPSHOT_FIELDS if field in item}

--- a/muckrockbot/download.py
+++ b/muckrockbot/download.py
@@ -1,56 +1,84 @@
 import json
-import typing
+import os
 from datetime import datetime
 from pathlib import Path
 
 import click
 import pytz
-from muckrock import MuckRock
 from rich import print
+
+from muckrockbot.client import DownloadError, PublicFoiaClient, RequestRecord
 
 DATA_DIR = Path(__file__).parent.parent / "data"
 
 
 @click.command()
-def cli() -> None:
+@click.option(
+    "--check", is_flag=True, help="Check authenticated downloads without writing files."
+)
+@click.option(
+    "--allow-public-feed",
+    is_flag=True,
+    envvar="MUCKROCK_PUBLIC_FEED_APPROVED",
+    help="Allow saving public requests, including records excluded from anonymous feeds.",
+)
+@click.option(
+    "--data-dir",
+    type=click.Path(file_okay=False, path_type=Path),
+    help="Snapshot directory. Defaults to the project's data directory.",
+)
+def cli(check: bool, allow_public_feed: bool, data_dir: Path | None) -> None:
     """Download request snapshots from the MuckRock API.
 
+    \f
     Args:
-        None.
+        check: Validate downloads without writing snapshots.
+        allow_public_feed: Acknowledge the authenticated feed's visibility difference.
+        data_dir: Snapshot directory, or None to use the project's data directory.
 
     Returns:
-        None. JSON snapshots are written to the project's data directory.
+        None. Validated snapshots are written unless check is selected.
+
+    Raises:
+        click.ClickException: Approval, authentication, or download validation fails.
 
     Example:
-        Run ``python -m muckrockbot.download``.
+        Run ``python -m muckrockbot.download --check``.
     """
-    DATA_DIR.mkdir(exist_ok=True)
+    if not check and not allow_public_feed:
+        raise click.ClickException(
+            "Saving the authenticated public feed requires approval because it may "
+            "include requests excluded from anonymous feeds. Use --check first; "
+            "set MUCKROCK_PUBLIC_FEED_APPROVED=true only after approving that change."
+        )
+    try:
+        client = PublicFoiaClient(os.environ.get("MUCKROCK_API_TOKEN", ""))
+        submitted_list = client.submitted()
+        completed_list = client.completed()
+    except DownloadError as error:
+        raise click.ClickException(str(error)) from error
 
-    # Create the MuckRock client
-    client = MuckRock()
-
-    # Pull the submitted
-    submitted_list = client.foia.filter(
-        ordering="-datetime_submitted", has_datetime_submitted=True
-    )
-
-    # Pull the completed
-    completed_list = client.foia.filter(
-        ordering="-datetime_done", has_datetime_done=True, status="done"
-    )
+    if check:
+        click.echo(
+            f"Checked {len(submitted_list)} submitted and {len(completed_list)} "
+            "completed public requests. No files were written or posts sent. "
+            "The API does not identify records excluded from anonymous feeds."
+        )
+        return
 
     # Get the current time
     tz = pytz.timezone("America/Los_Angeles")
     now = datetime.now(tz=tz)
+    output_dir = data_dir if data_dir is not None else DATA_DIR
 
     # Write them out
-    write_json(submitted_list, DATA_DIR / "submitted" / f"{now}.json")
-    write_json(submitted_list, DATA_DIR / "submitted" / "latest.json")
-    write_json(completed_list, DATA_DIR / "completed" / f"{now}.json")
-    write_json(completed_list, DATA_DIR / "completed" / "latest.json")
+    write_json(submitted_list, output_dir / "submitted" / f"{now}.json")
+    write_json(submitted_list, output_dir / "submitted" / "latest.json")
+    write_json(completed_list, output_dir / "completed" / f"{now}.json")
+    write_json(completed_list, output_dir / "completed" / "latest.json")
 
 
-def write_json(data: typing.Any, path: Path, indent: int = 2) -> None:
+def write_json(data: list[RequestRecord], path: Path, indent: int = 2) -> None:
     """Write JSON-compatible data to a path.
 
     Args:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "python-muckrock==0.1.1",
     "python-twitter>=3.5",
     "pytz>=2022.6",
+    "requests>=2.32",
     "rich>=12.6",
 ]
 classifiers = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,42 @@
+"""Keep command and client tests independent of real services and credentials."""
+
+import pytest
+import requests
+
+
+@pytest.fixture(autouse=True)
+def isolate_external_services(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Remove real credentials and block unmocked HTTP requests.
+
+    Args:
+        monkeypatch: Pytest helper for restoring patched objects and environment.
+
+    Returns:
+        None. Each test must supply synthetic credentials and HTTP responses.
+
+    Example:
+        Pytest applies this fixture automatically to every test.
+    """
+
+    def fail_outbound_request(*args: object, **kwargs: object) -> requests.Response:
+        """Reject an unmocked HTTP operation.
+
+        Args:
+            *args: Positional transport arguments.
+            **kwargs: Keyword transport arguments.
+
+        Returns:
+            This function does not return.
+
+        Raises:
+            AssertionError: Always, to prevent access to external services.
+
+        Example:
+            An unmocked ``requests.get(url)`` fails rather than accessing the API.
+        """
+        raise AssertionError("Tests must explicitly mock HTTP requests.")
+
+    monkeypatch.delenv("MUCKROCK_API_TOKEN", raising=False)
+    monkeypatch.delenv("MUCKROCK_PUBLIC_FEED_APPROVED", raising=False)
+    monkeypatch.setattr(requests, "get", fail_outbound_request)
+    monkeypatch.setattr(requests.sessions.Session, "send", fail_outbound_request)

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,0 +1,62 @@
+"""Synthetic MuckRock responses shared by offline tests."""
+
+import json
+
+import requests
+
+
+def make_response(
+    payload: object, status_code: int = 200, raw_content: bytes | None = None
+) -> requests.Response:
+    """Build an in-memory HTTP response.
+
+    Args:
+        payload: JSON value used when no raw content is supplied.
+        status_code: HTTP status attached to the response.
+        raw_content: Optional raw response bytes, such as invalid JSON.
+
+    Returns:
+        A response that supports normal Requests status and JSON handling.
+
+    Example:
+        ``make_response({"results": []})``.
+    """
+    response = requests.Response()
+    response.status_code = status_code
+    response.url = "https://www.muckrock.com/api_v1/foia"
+    response.headers["Content-Type"] = "application/json"
+    response._content = (
+        raw_content if raw_content is not None else json.dumps(payload).encode()
+    )
+    return response
+
+
+def request_row(
+    request_id: int, *, completed: bool = False, **overrides: object
+) -> dict[str, object]:
+    """Build a public request fixture.
+
+    Args:
+        request_id: Positive request identifier.
+        completed: Whether to create a completed request.
+        **overrides: Values that replace standard fixture fields.
+
+    Returns:
+        A JSON-compatible public request record.
+
+    Example:
+        ``request_row(7, completed=True)``.
+    """
+    row: dict[str, object] = {
+        "id": request_id,
+        "title": "Request title",
+        "username": "public-requester",
+        "absolute_url": f"https://www.muckrock.com/foi/example/request-{request_id}/",
+        "status": "done" if completed else "submitted",
+        "embargo_status": "public",
+        "datetime_submitted": "2026-09-01T12:00:00+00:00",
+    }
+    if completed:
+        row["datetime_done"] = "2026-09-02T12:00:00+00:00"
+    row.update(overrides)
+    return row

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,65 +1,308 @@
 import json
+from datetime import UTC, datetime, tzinfo
+from pathlib import Path
 
+import pytest
+import requests
 from click.testing import CliRunner
 
-from muckrockbot import download, transform
+from muckrockbot import client, download, transform
+from tests.helpers import make_response, request_row
 
 
-def test_download_cli(tmp_path, monkeypatch):
-    """Write submitted and completed snapshots without calling MuckRock.
+def assert_json_primitives(value: object) -> None:
+    """Assert that a decoded value consists only of JSON primitives and containers.
+
+    Args:
+        value: Decoded JSON value to validate recursively.
+
+    Returns:
+        None. Raises an assertion error when an unsupported value is encountered.
+
+    Example:
+        ``assert_json_primitives({"id": 1, "tags": []})``.
+    """
+    if isinstance(value, dict):
+        assert all(isinstance(key, str) for key in value)
+        for item in value.values():
+            assert_json_primitives(item)
+    elif isinstance(value, list):
+        for item in value:
+            assert_json_primitives(item)
+    else:
+        assert value is None or type(value) in {bool, int, float, str}
+
+
+@pytest.mark.parametrize("approval_source", ["flag", "environment"])
+def test_download_cli_writes_four_consistent_json_snapshots(
+    approval_source: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Write both validated feeds with one frozen timestamp and no private fields.
+
+    Args:
+        approval_source: Mechanism used to explicitly approve snapshot writing.
+        tmp_path: Temporary directory supplied by pytest.
+        monkeypatch: Pytest helper for replacing dependencies.
+
+    Returns:
+        None. Assertions confirm all output is JSON-compatible and consistently named.
+
+    Example:
+        Run with ``pytest tests/test_cli.py::test_download_cli_writes_four_consistent_json_snapshots``.
+    """
+    submitted = request_row(
+        1,
+        agency="Example agency",
+        tags=["transparency"],
+        notes="private notes",
+        email="private@example.com",
+        mail_id=9,
+        read_collaborators=["staff"],
+        edit_collaborators=["staff"],
+    )
+    completed = request_row(2, completed=True, communications=[])
+    responses = [
+        make_response({"results": [submitted]}),
+        make_response({"results": [completed]}),
+    ]
+
+    def queued_get(url: str, **kwargs: object) -> requests.Response:
+        """Return the next expected response without performing I/O.
+
+        Args:
+            url: Requested endpoint URL.
+            **kwargs: Request arguments passed by the client.
+
+        Returns:
+            The next queued synthetic response.
+
+        Example:
+            ``queued_get("https://www.muckrock.com/api_v1/foia")``.
+        """
+        assert url == "https://www.muckrock.com/api_v1/foia"
+        assert kwargs["timeout"] == 20
+        return responses.pop(0)
+
+    class FrozenDatetime(datetime):
+        """Provide a stable instant for timestamped snapshot names."""
+
+        @classmethod
+        def now(cls, tz: tzinfo | None = None) -> datetime:
+            """Return the fixture instant in the requested timezone.
+
+            Args:
+                tz: Timezone requested by the download command.
+
+            Returns:
+                A stable timezone-aware timestamp.
+
+            Example:
+                ``FrozenDatetime.now(UTC)``.
+            """
+            instant = datetime(2026, 9, 6, 16, 12, tzinfo=UTC)
+            return instant if tz is None else instant.astimezone(tz)
+
+    monkeypatch.setenv("MUCKROCK_API_TOKEN", "test-token")
+    monkeypatch.setattr(client.requests, "get", queued_get)
+    monkeypatch.setattr(download, "datetime", FrozenDatetime)
+    command = ["--data-dir", str(tmp_path)]
+    if approval_source == "flag":
+        command.insert(0, "--allow-public-feed")
+    else:
+        monkeypatch.setenv("MUCKROCK_PUBLIC_FEED_APPROVED", "true")
+
+    runner = CliRunner()
+    result = runner.invoke(download.cli, command)
+
+    assert result.exit_code == 0
+    assert responses == []
+    submitted_paths = sorted((tmp_path / "submitted").glob("*.json"))
+    completed_paths = sorted((tmp_path / "completed").glob("*.json"))
+    assert [path.name for path in submitted_paths] == [
+        "2026-09-06 09:12:00-07:00.json",
+        "latest.json",
+    ]
+    assert [path.name for path in completed_paths] == [
+        "2026-09-06 09:12:00-07:00.json",
+        "latest.json",
+    ]
+    for path in [*submitted_paths, *completed_paths]:
+        assert_json_primitives(json.loads(path.read_text()))
+    assert json.loads((tmp_path / "submitted" / "latest.json").read_text()) == [
+        {
+            key: value
+            for key, value in submitted.items()
+            if key
+            not in {
+                "notes",
+                "email",
+                "mail_id",
+                "read_collaborators",
+                "edit_collaborators",
+            }
+        }
+    ]
+    assert json.loads((tmp_path / "completed" / "latest.json").read_text()) == [
+        completed
+    ]
+
+
+def test_check_download_does_not_create_the_requested_directory(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Check both feeds without creating directories or snapshot files.
 
     Args:
         tmp_path: Temporary directory supplied by pytest.
         monkeypatch: Pytest helper for replacing dependencies.
 
     Returns:
-        None. Assertions confirm both latest snapshot files were written.
+        None. Assertions confirm check mode performs no writes.
 
     Example:
-        Run with ``pytest tests/test_cli.py::test_download_cli``.
+        Run with ``pytest tests/test_cli.py::test_check_download_does_not_create_the_requested_directory``.
     """
-    submitted_requests = [{"id": 1, "title": "Submitted request"}]
-    completed_requests = [{"id": 2, "title": "Completed request"}]
+    output_dir = tmp_path / "not-created"
+    responses = [make_response({"results": []}), make_response({"results": []})]
 
-    class FakeFoia:
-        """Return fixture data for the legacy endpoint calls."""
+    def queued_get(url: str, **kwargs: object) -> requests.Response:
+        """Return the next checked feed response.
 
-        def filter(self, **kwargs: object) -> list[dict[str, int | str]]:
-            """Return fixture data matching the requested sort field.
+        Args:
+            url: Requested endpoint URL.
+            **kwargs: Request arguments passed by the client.
 
-            Args:
-                **kwargs: Endpoint query options, including ``ordering``.
+        Returns:
+            The next queued synthetic response.
 
-            Returns:
-                Fixture requests for the requested sort order.
+        Example:
+            ``queued_get("https://www.muckrock.com/api_v1/foia")``.
+        """
+        return responses.pop(0)
 
-            Example:
-                ``FakeFoia().filter(ordering="-datetime_submitted")``.
-            """
-            if kwargs["ordering"] == "-datetime_submitted":
-                return submitted_requests
-            return completed_requests
+    monkeypatch.setenv("MUCKROCK_API_TOKEN", "test-token")
+    monkeypatch.setattr(client.requests, "get", queued_get)
 
-    class FakeMuckRock:
-        """Provide the endpoint object expected by the download command."""
-
-        foia = FakeFoia()
-
-    monkeypatch.setattr(download, "DATA_DIR", tmp_path)
-    monkeypatch.setattr(download, "MuckRock", FakeMuckRock)
-
-    runner = CliRunner()
-    result = runner.invoke(download.cli, [])
+    result = CliRunner().invoke(
+        download.cli, ["--check", "--data-dir", str(output_dir)]
+    )
 
     assert result.exit_code == 0
-    assert (
-        json.loads((tmp_path / "submitted" / "latest.json").read_text())
-        == submitted_requests
+    assert responses == []
+    assert not output_dir.exists()
+    assert "No files were written or posts sent" in result.output
+
+
+def test_failure_after_submitted_preserves_existing_snapshots(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Leave all existing snapshots untouched when the completed feed fails.
+
+    Args:
+        tmp_path: Temporary directory supplied by pytest.
+        monkeypatch: Pytest helper for replacing dependencies.
+
+    Returns:
+        None. Assertions confirm no partial snapshot write occurs.
+
+    Example:
+        Run with ``pytest tests/test_cli.py::test_failure_after_submitted_preserves_existing_snapshots``.
+    """
+    original_files = {
+        tmp_path / "submitted" / "latest.json": '[{"id": 99}]',
+        tmp_path / "completed" / "latest.json": '[{"id": 98}]',
+    }
+    for path, content in original_files.items():
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content)
+
+    calls = 0
+
+    def submitted_then_timeout(url: str, **kwargs: object) -> requests.Response:
+        """Return submitted data once and then simulate a timeout.
+
+        Args:
+            url: Requested endpoint URL.
+            **kwargs: Request arguments passed by the client.
+
+        Returns:
+            The synthetic submitted response on its first invocation.
+
+        Raises:
+            requests.Timeout: Always on the second invocation.
+
+        Example:
+            ``submitted_then_timeout("https://www.muckrock.com/api_v1/foia")``.
+        """
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            return make_response({"results": [request_row(1)]})
+        raise requests.Timeout("network details must not reach command output")
+
+    monkeypatch.setenv("MUCKROCK_API_TOKEN", "test-token")
+    monkeypatch.setattr(client.requests, "get", submitted_then_timeout)
+
+    result = CliRunner().invoke(
+        download.cli, ["--allow-public-feed", "--data-dir", str(tmp_path)]
     )
-    assert (
-        json.loads((tmp_path / "completed" / "latest.json").read_text())
-        == completed_requests
-    )
+
+    assert result.exit_code == 1
+    assert calls == 2
+    assert {path: path.read_text() for path in original_files} == original_files
+    assert set(tmp_path.rglob("*.json")) == set(original_files)
+
+
+def test_writing_requires_explicit_public_feed_approval(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Reject snapshot writes unless approval is supplied as the true flag value.
+
+    Args:
+        tmp_path: Temporary directory supplied by pytest.
+        monkeypatch: Pytest helper for setting the approval environment variable.
+
+    Returns:
+        None. Assertions confirm an unapproved command performs no request or write.
+
+    Example:
+        Run with ``pytest tests/test_cli.py::test_writing_requires_explicit_public_feed_approval``.
+    """
+    output_dir = tmp_path / "approval-required"
+    monkeypatch.setenv("MUCKROCK_PUBLIC_FEED_APPROVED", "false")
+
+    result = CliRunner().invoke(download.cli, ["--data-dir", str(output_dir)])
+
+    assert result.exit_code == 1
+    assert "requires approval" in result.output
+    assert not output_dir.exists()
+
+
+@pytest.mark.parametrize("token", [None, "", " \t ", "token\nvalue"])
+def test_download_requires_a_nonempty_safe_api_token(
+    token: str | None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Reject absent, blank, or newline-containing API tokens before any request.
+
+    Args:
+        token: Environment value to validate.
+        monkeypatch: Pytest helper for replacing environment variables.
+
+    Returns:
+        None. Assertions confirm a safe credential error is displayed.
+
+    Example:
+        Run with ``pytest tests/test_cli.py::test_download_requires_a_nonempty_safe_api_token``.
+    """
+    if token is None:
+        monkeypatch.delenv("MUCKROCK_API_TOKEN", raising=False)
+    else:
+        monkeypatch.setenv("MUCKROCK_API_TOKEN", token)
+
+    result = CliRunner().invoke(download.cli, ["--check"])
+
+    assert result.exit_code == 1
+    assert "Set MUCKROCK_API_TOKEN" in result.output
 
 
 def test_transform_cli(tmp_path, monkeypatch):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,0 +1,474 @@
+"""Offline regression tests for authenticated MuckRock v1 downloads."""
+
+import pytest
+import requests
+
+from muckrockbot import client
+from tests.helpers import make_response, request_row
+
+
+@pytest.mark.parametrize(
+    ("method", "expected_params"),
+    [
+        (
+            "submitted",
+            {
+                "ordering": "-datetime_submitted",
+                "has_datetime_submitted": 2,
+                "has_datetime_done": 1,
+                "embargo_status": "public",
+                "page_size": 50,
+            },
+        ),
+        (
+            "completed",
+            {
+                "ordering": "-datetime_done",
+                "has_datetime_submitted": 1,
+                "has_datetime_done": 2,
+                "status": "done",
+                "embargo_status": "public",
+                "page_size": 50,
+            },
+        ),
+    ],
+)
+def test_legacy_filter_encodes_public_feed_queries(
+    method: str, expected_params: dict[str, str | int], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Use the inherited filter encoding with the hardened v1 transport.
+
+    Args:
+        method: Public feed method to call.
+        expected_params: Exact query encoding expected from the legacy filter.
+        monkeypatch: Pytest helper for replacing the request seam.
+
+    Returns:
+        None. Assertions confirm query, headers, and timeout values.
+
+    Example:
+        Run with ``pytest tests/test_client.py::test_legacy_filter_encodes_public_feed_queries``.
+    """
+    calls: list[tuple[str, dict[str, object]]] = []
+    completed = method == "completed"
+
+    def capture_get(url: str, **kwargs: object) -> requests.Response:
+        """Capture one expected legacy request and return a valid page.
+
+        Args:
+            url: Requested endpoint URL.
+            **kwargs: Request arguments passed by the client.
+
+        Returns:
+            A synthetic one-record response.
+
+        Example:
+            ``capture_get("https://www.muckrock.com/api_v1/foia")``.
+        """
+        calls.append((url, kwargs))
+        return make_response({"results": [request_row(1, completed=completed)]})
+
+    monkeypatch.setattr(client.requests, "get", capture_get)
+
+    records = getattr(client.PublicFoiaClient("test-token"), method)()
+
+    assert records[0]["id"] == 1
+    assert calls == [
+        (
+            "https://www.muckrock.com/api_v1/foia",
+            {
+                "params": expected_params,
+                "headers": {
+                    "Authorization": "Token test-token",
+                    "User-Agent": client.PublicFoiaClient.USER_AGENT,
+                    "Accept": "application/json",
+                },
+                "timeout": 20,
+            },
+        )
+    ]
+
+
+@pytest.mark.parametrize("records", [[], [request_row(1)]])
+def test_client_accepts_empty_and_short_public_pages(
+    records: list[dict[str, object]], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Accept valid first pages that contain fewer than the requested 50 records.
+
+    Args:
+        records: Valid result rows for the synthetic page.
+        monkeypatch: Pytest helper for replacing the request seam.
+
+    Returns:
+        None. Assertions confirm valid responses are returned unchanged.
+
+    Example:
+        Run with ``pytest tests/test_client.py::test_client_accepts_empty_and_short_public_pages``.
+    """
+    monkeypatch.setattr(
+        client.requests,
+        "get",
+        lambda *args, **kwargs: make_response({"results": records}),
+    )
+
+    assert client.PublicFoiaClient("test-token").submitted() == records
+
+
+def test_client_ignores_next_page_link(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Download only the initial 50-record page even when a next link is supplied.
+
+    Args:
+        monkeypatch: Pytest helper for replacing the request seam.
+
+    Returns:
+        None. Assertions confirm no second request is issued.
+
+    Example:
+        Run with ``pytest tests/test_client.py::test_client_ignores_next_page_link``.
+    """
+    calls = 0
+    rows = [request_row(index) for index in range(50, 0, -1)]
+
+    def page_with_next(url: str, **kwargs: object) -> requests.Response:
+        """Return one page that advertises a next URL.
+
+        Args:
+            url: Requested endpoint URL.
+            **kwargs: Request arguments passed by the client.
+
+        Returns:
+            A synthetic response containing a ``next`` link.
+
+        Example:
+            ``page_with_next("https://www.muckrock.com/api_v1/foia")``.
+        """
+        nonlocal calls
+        calls += 1
+        return make_response(
+            {
+                "next": "https://www.muckrock.com/api_v1/foia?page=2",
+                "results": rows,
+            }
+        )
+
+    monkeypatch.setattr(client.requests, "get", page_with_next)
+
+    assert client.PublicFoiaClient("test-token").submitted() == rows
+    assert calls == 1
+
+
+@pytest.mark.parametrize(
+    ("payload", "raw_content", "expected_message"),
+    [
+        ({}, None, "missing a results list"),
+        ({"results": {}}, None, "missing a results list"),
+        (None, b"<html>login page</html>", "invalid JSON"),
+    ],
+)
+def test_client_rejects_invalid_response_envelopes(
+    payload: object,
+    raw_content: bytes | None,
+    expected_message: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Reject missing results lists and non-JSON response bodies safely.
+
+    Args:
+        payload: JSON payload for the response.
+        raw_content: Optional invalid response content.
+        expected_message: Safe error text expected from the client.
+        monkeypatch: Pytest helper for replacing the request seam.
+
+    Returns:
+        None. Assertions confirm response bodies are not exposed.
+
+    Example:
+        Run with ``pytest tests/test_client.py::test_client_rejects_invalid_response_envelopes``.
+    """
+    monkeypatch.setattr(
+        client.requests,
+        "get",
+        lambda *args, **kwargs: make_response(payload, raw_content=raw_content),
+    )
+
+    with pytest.raises(client.DownloadError, match=expected_message) as error:
+        client.PublicFoiaClient("test-token").submitted()
+
+    assert "login page" not in str(error.value)
+
+
+@pytest.mark.parametrize(
+    ("status_code", "expected_message"),
+    [
+        (401, "rejected access"),
+        (403, "rejected access"),
+        (404, "HTTP 404"),
+        (429, "rate limit"),
+        (500, "HTTP 500"),
+    ],
+)
+def test_client_reports_safe_http_errors(
+    status_code: int, expected_message: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Convert API HTTP failures into messages that expose no response details.
+
+    Args:
+        status_code: Synthetic HTTP response status.
+        expected_message: Safe error text expected from the client.
+        monkeypatch: Pytest helper for replacing the request seam.
+
+    Returns:
+        None. Assertions confirm status-specific safe errors are raised.
+
+    Example:
+        Run with ``pytest tests/test_client.py::test_client_reports_safe_http_errors``.
+    """
+    monkeypatch.setattr(
+        client.requests,
+        "get",
+        lambda *args, **kwargs: make_response(
+            {"detail": "token-secret and response body must not be shown"}, status_code
+        ),
+    )
+
+    with pytest.raises(client.DownloadError, match=expected_message) as error:
+        client.PublicFoiaClient("test-token").submitted()
+
+    assert "token-secret" not in str(error.value)
+
+
+def test_client_reports_timeout_without_network_details(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Convert transport failures to a generic actionable download error.
+
+    Args:
+        monkeypatch: Pytest helper for replacing the request seam.
+
+    Returns:
+        None. Assertions confirm timeout internals are not exposed.
+
+    Example:
+        Run with ``pytest tests/test_client.py::test_client_reports_timeout_without_network_details``.
+    """
+
+    def raise_timeout(*args: object, **kwargs: object) -> requests.Response:
+        """Raise a synthetic timeout from the request seam.
+
+        Args:
+            *args: Positional arguments passed to ``requests.get``.
+            **kwargs: Keyword arguments passed to ``requests.get``.
+
+        Returns:
+            This function does not return.
+
+        Raises:
+            requests.Timeout: Always.
+
+        Example:
+            ``raise_timeout()``.
+        """
+        raise requests.Timeout("private connection detail")
+
+    monkeypatch.setattr(client.requests, "get", raise_timeout)
+
+    with pytest.raises(client.DownloadError, match="Could not reach MuckRock") as error:
+        client.PublicFoiaClient("test-token").submitted()
+
+    assert "private connection detail" not in str(error.value)
+
+
+def test_client_rejects_pages_larger_than_fifty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Reject a response that violates the one-page record limit.
+
+    Args:
+        monkeypatch: Pytest helper for replacing the request seam.
+
+    Returns:
+        None. Assertions confirm oversized pages are not accepted.
+
+    Example:
+        Run with ``pytest tests/test_client.py::test_client_rejects_pages_larger_than_fifty``.
+    """
+    rows = [request_row(index) for index in range(1, 52)]
+    monkeypatch.setattr(
+        client.requests, "get", lambda *args, **kwargs: make_response({"results": rows})
+    )
+
+    with pytest.raises(client.DownloadError, match="more than the requested 50"):
+        client.PublicFoiaClient("test-token").submitted()
+
+
+@pytest.mark.parametrize(
+    "field", ["title", "username", "absolute_url", "status", "datetime_submitted"]
+)
+def test_client_rejects_missing_required_submitted_fields(
+    field: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Reject submitted rows that omit a required public snapshot field.
+
+    Args:
+        field: Required field removed from the valid fixture.
+        monkeypatch: Pytest helper for replacing the request seam.
+
+    Returns:
+        None. Assertions confirm the field-specific validation failure.
+
+    Example:
+        Run with ``pytest tests/test_client.py::test_client_rejects_missing_required_submitted_fields``.
+    """
+    row = request_row(1)
+    row.pop(field)
+    monkeypatch.setattr(
+        client.requests,
+        "get",
+        lambda *args, **kwargs: make_response({"results": [row]}),
+    )
+
+    with pytest.raises(client.DownloadError, match=f"valid {field}"):
+        client.PublicFoiaClient("test-token").submitted()
+
+
+@pytest.mark.parametrize(
+    ("row", "method", "expected_message"),
+    [
+        ("not a request object", "submitted", "not an object"),
+        (request_row(1, id=True), "submitted", "valid integer ID"),
+        (request_row(1, id="1"), "submitted", "valid integer ID"),
+        (request_row(0), "submitted", "valid integer ID"),
+        (request_row(1, username=" "), "submitted", "valid username"),
+        (request_row(1, embargo_status="private"), "submitted", "non-public"),
+        (request_row(1, embargo_status=None), "submitted", "non-public"),
+        (
+            request_row(1, datetime_submitted=None),
+            "submitted",
+            "valid datetime_submitted",
+        ),
+        (
+            request_row(1, datetime_submitted="yesterday"),
+            "submitted",
+            "invalid request date or URL",
+        ),
+        (
+            request_row(1, absolute_url="https://example.com/foi/request"),
+            "submitted",
+            "outside its public site",
+        ),
+        (
+            request_row(1, completed=True, status="processing"),
+            "completed",
+            "status done",
+        ),
+        (
+            request_row(1, completed=True, datetime_done=None),
+            "completed",
+            "valid datetime_done",
+        ),
+    ],
+)
+def test_client_rejects_malformed_or_nonpublic_records(
+    row: object,
+    method: str,
+    expected_message: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Reject malformed IDs, public status violations, invalid links, and bad dates.
+
+    Args:
+        row: Synthetic invalid result row.
+        method: Feed method through which to validate the row.
+        expected_message: Validation text expected from the client.
+        monkeypatch: Pytest helper for replacing the request seam.
+
+    Returns:
+        None. Assertions confirm invalid rows cannot become snapshots.
+
+    Example:
+        Run with ``pytest tests/test_client.py::test_client_rejects_malformed_or_nonpublic_records``.
+    """
+    monkeypatch.setattr(
+        client.requests,
+        "get",
+        lambda *args, **kwargs: make_response({"results": [row]}),
+    )
+
+    with pytest.raises(client.DownloadError, match=expected_message):
+        getattr(client.PublicFoiaClient("test-token"), method)()
+
+
+def test_client_rejects_duplicate_ids(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Reject a first page containing the same request identifier twice.
+
+    Args:
+        monkeypatch: Pytest helper for replacing the request seam.
+
+    Returns:
+        None. Assertions confirm duplicate records are not returned.
+
+    Example:
+        Run with ``pytest tests/test_client.py::test_client_rejects_duplicate_ids``.
+    """
+    monkeypatch.setattr(
+        client.requests,
+        "get",
+        lambda *args, **kwargs: make_response(
+            {"results": [request_row(1), request_row(1, title="Repeated")]}
+        ),
+    )
+
+    with pytest.raises(client.DownloadError, match="duplicate request IDs"):
+        client.PublicFoiaClient("test-token").submitted()
+
+
+def test_client_drops_authenticated_only_top_level_fields(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Keep existing snapshot fields while removing account-only response metadata.
+
+    Args:
+        monkeypatch: Pytest helper for replacing the request seam.
+
+    Returns:
+        None. Assertions confirm private top-level fields never leave the client.
+
+    Example:
+        Run with ``pytest tests/test_client.py::test_client_drops_authenticated_only_top_level_fields``.
+    """
+    row = request_row(
+        1,
+        agency="Example agency",
+        tags=["transparency"],
+        notes="private note",
+        email="private@example.com",
+        mail_id=3,
+        read_collaborators=["staff"],
+        edit_collaborators=["staff"],
+    )
+    monkeypatch.setattr(
+        client.requests,
+        "get",
+        lambda *args, **kwargs: make_response({"results": [row]}),
+    )
+
+    records = client.PublicFoiaClient("test-token").submitted()
+
+    assert records == [
+        {
+            key: value
+            for key, value in row.items()
+            if key
+            not in {
+                "notes",
+                "email",
+                "mail_id",
+                "read_collaborators",
+                "edit_collaborators",
+            }
+        }
+    ]

--- a/uv.lock
+++ b/uv.lock
@@ -413,6 +413,7 @@ dependencies = [
     { name = "python-muckrock" },
     { name = "python-twitter" },
     { name = "pytz" },
+    { name = "requests" },
     { name = "rich" },
 ]
 
@@ -433,6 +434,7 @@ requires-dist = [
     { name = "python-muckrock", specifier = "==0.1.1" },
     { name = "python-twitter", specifier = ">=3.5" },
     { name = "pytz", specifier = ">=2022.6" },
+    { name = "requests", specifier = ">=2.32" },
     { name = "rich", specifier = ">=12.6" },
 ]
 


### PR DESCRIPTION
## Summary

Restore the maintainer-supported API v1 integration using the existing `MUCKROCK_API_TOKEN` secret and pinned `python-muckrock==0.1.1`. This builds on the tooling changes already merged in #25; it does not migrate to API v2.

- Preserve the latest 50 submitted/completed requests, legacy date filters, author names, URLs and snapshot filenames.
- Add HTTP timeouts, clear authentication/API errors, strict public-record validation and filtering of authenticated-only metadata. Fetch and validate both feeds before writing snapshots.
- Add `download --check` for authenticated checks without writing data or posting, plus explicit approval for saving the broader authenticated public feed.
- Wire the token only into download/check steps. Until `MUCKROCK_PUBLIC_FEED_APPROVED` is set to `true`, scheduled runs only check access.
- Add a manual `baseline` run that saves an explicitly approved feed without posting, allowing a safe restart after downtime.
- Serialize ETL runs and commit generated files before rebasing; stage only the two data directories.

## Publication remains gated

Authenticated v1 can return public requests marked `noindex` that the old anonymous feed excluded. Its response does not identify those records. This PR does **not** claim to resolve that upstream limitation, enable publication, change repository variables, or use the token locally.

To retain the old exclusions, leave publishing disabled pending a supported API solution. If the owner explicitly accepts the broader public feed, run the manual baseline first, then set `MUCKROCK_PUBLIC_FEED_APPROVED=true`. The README documents these steps.

## Validation

- 44 offline tests covering real legacy filter encoding, response errors, required fields, the 50-record boundary, ignored pagination links, credentials, approval, check mode and preservation of snapshots when the second feed fails.
- Shared test fixtures remove real credentials and reject unmocked HTTP requests.
- Ruff, ty and all existing pre-commit hooks passed, including Actionlint and secret detection.
- No historical data was changed and no live API or social posting commands were run.